### PR TITLE
[Feat] 옵저버 패턴 마무리 및 구독 기능 그리드버전 추가

### DIFF
--- a/constant/constants.js
+++ b/constant/constants.js
@@ -1,5 +1,7 @@
 // 그리드에 들어갈 언론사 수
 export const MAX_GRID_COUNT = 24;
+// 언론사의 수
+export const PRESS_COUNT = 96;
 // 롤링에 들어갈 뉴스 수
 export const ROLLING_NEWS_NUM = 5;
 // 좌우 롤링 시간 차

--- a/constant/pressObj.json
+++ b/constant/pressObj.json
@@ -4,673 +4,577 @@
       "id": 1,
       "name": "YTN 사이언스",
       "darkSrc": "./assets/logo/dark/img1.svg",
-      "lightSrc": "./assets/logo/light/img1.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img1.svg"
     },
     {
       "id": 2,
       "name": "Able뉴스",
       "darkSrc": "./assets/logo/dark/img2.svg",
-      "lightSrc": "./assets/logo/light/img2.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img2.svg"
     },
     {
       "id": 3,
       "name": "뉴스토마토",
       "darkSrc": "./assets/logo/dark/img3.svg",
-      "lightSrc": "./assets/logo/light/img3.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img3.svg"
     },
     {
       "id": 4,
       "name": "데일리한국",
       "darkSrc": "./assets/logo/dark/img4.svg",
-      "lightSrc": "./assets/logo/light/img4.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img4.svg"
     },
     {
       "id": 5,
       "name": "시사오늘",
       "darkSrc": "./assets/logo/dark/img5.svg",
-      "lightSrc": "./assets/logo/light/img5.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img5.svg"
     },
     {
       "id": 6,
       "name": "대전방송",
       "darkSrc": "./assets/logo/dark/img6.svg",
-      "lightSrc": "./assets/logo/light/img6.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img6.svg"
     },
     {
       "id": 7,
       "name": "이코노타임즈",
       "darkSrc": "./assets/logo/dark/img7.svg",
-      "lightSrc": "./assets/logo/light/img7.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img7.svg"
     },
     {
       "id": 8,
       "name": "독서신문",
       "darkSrc": "./assets/logo/dark/img8.svg",
-      "lightSrc": "./assets/logo/light/img8.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img8.svg"
     },
     {
       "id": 9,
       "name": "산",
       "darkSrc": "./assets/logo/dark/img9.svg",
-      "lightSrc": "./assets/logo/light/img9.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img9.svg"
     },
     {
       "id": 10,
       "name": "시사 IN",
       "darkSrc": "./assets/logo/dark/img10.svg",
-      "lightSrc": "./assets/logo/light/img10.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img10.svg"
     },
     {
       "id": 11,
       "name": "한국경제",
       "darkSrc": "./assets/logo/dark/img11.svg",
-      "lightSrc": "./assets/logo/light/img11.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img11.svg"
     },
     {
       "id": 12,
       "name": "NEWSIS",
       "darkSrc": "./assets/logo/dark/img12.svg",
-      "lightSrc": "./assets/logo/light/img12.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img12.svg"
     },
     {
       "id": 13,
       "name": "동아일보",
       "darkSrc": "./assets/logo/dark/img13.svg",
-      "lightSrc": "./assets/logo/light/img13.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img13.svg"
     },
     {
       "id": 14,
       "name": "KBS",
       "darkSrc": "./assets/logo/dark/img14.svg",
-      "lightSrc": "./assets/logo/light/img14.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img14.svg"
     },
     {
       "id": 15,
       "name": "BLOTER",
       "darkSrc": "./assets/logo/dark/img15.svg",
-      "lightSrc": "./assets/logo/light/img15.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img15.svg"
     },
     {
       "id": 16,
       "name": "한국경제TV",
       "darkSrc": "./assets/logo/dark/img16.svg",
-      "lightSrc": "./assets/logo/light/img16.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img16.svg"
     },
     {
       "id": 17,
       "name": "전자신문",
       "darkSrc": "./assets/logo/dark/img17.svg",
-      "lightSrc": "./assets/logo/light/img17.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img17.svg"
     },
     {
       "id": 18,
       "name": "스포츠조선",
       "darkSrc": "./assets/logo/dark/img18.svg",
-      "lightSrc": "./assets/logo/light/img18.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img18.svg"
     },
     {
       "id": 19,
       "name": "서울신문",
       "darkSrc": "./assets/logo/dark/img19.svg",
-      "lightSrc": "./assets/logo/light/img19.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img19.svg"
     },
     {
       "id": 20,
       "name": "중앙일보",
       "darkSrc": "./assets/logo/dark/img20.svg",
-      "lightSrc": "./assets/logo/light/img20.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img20.svg"
     },
     {
       "id": 21,
       "name": "노컷뉴스",
       "darkSrc": "./assets/logo/dark/img21.svg",
-      "lightSrc": "./assets/logo/light/img21.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img21.svg"
     },
     {
       "id": 22,
       "name": "프레시안",
       "darkSrc": "./assets/logo/dark/img22.svg",
-      "lightSrc": "./assets/logo/light/img22.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img22.svg"
     },
     {
       "id": 23,
       "name": "sportalkorea",
       "darkSrc": "./assets/logo/dark/img23.svg",
-      "lightSrc": "./assets/logo/light/img23.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img23.svg"
     },
     {
       "id": 24,
       "name": "한국일보",
       "darkSrc": "./assets/logo/dark/img24.svg",
-      "lightSrc": "./assets/logo/light/img24.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img24.svg"
     },
     {
       "id": 25,
       "name": "여성경제신문",
       "darkSrc": "./assets/logo/dark/img25.svg",
-      "lightSrc": "./assets/logo/light/img25.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img25.svg"
     },
     {
       "id": 26,
       "name": "IT조선",
       "darkSrc": "./assets/logo/dark/img26.svg",
-      "lightSrc": "./assets/logo/light/img26.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img26.svg"
     },
     {
       "id": 27,
       "name": "철강금속신문",
       "darkSrc": "./assets/logo/dark/img27.svg",
-      "lightSrc": "./assets/logo/light/img27.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img27.svg"
     },
     {
       "id": 28,
       "name": "정신의학신문",
       "darkSrc": "./assets/logo/dark/img28.svg",
-      "lightSrc": "./assets/logo/light/img28.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img28.svg"
     },
     {
       "id": 29,
       "name": "뉴스포스트",
       "darkSrc": "./assets/logo/dark/img29.svg",
-      "lightSrc": "./assets/logo/light/img29.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img29.svg"
     },
     {
       "id": 30,
       "name": "씨네21",
       "darkSrc": "./assets/logo/dark/img30.svg",
-      "lightSrc": "./assets/logo/light/img30.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img30.svg"
     },
     {
       "id": 31,
       "name": "정책프리핑",
       "darkSrc": "./assets/logo/dark/img31.svg",
-      "lightSrc": "./assets/logo/light/img31.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img31.svg"
     },
     {
       "id": 32,
       "name": "텐아시아",
       "darkSrc": "./assets/logo/dark/img32.svg",
-      "lightSrc": "./assets/logo/light/img32.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img32.svg"
     },
     {
       "id": 33,
       "name": "MK스포츠",
       "darkSrc": "./assets/logo/dark/img33.svg",
-      "lightSrc": "./assets/logo/light/img33.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img33.svg"
     },
     {
       "id": 34,
       "name": "MONDE",
       "darkSrc": "./assets/logo/dark/img34.svg",
-      "lightSrc": "./assets/logo/light/img34.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img34.svg"
     },
     {
       "id": 35,
       "name": "BBS NEWS",
       "darkSrc": "./assets/logo/dark/img35.svg",
-      "lightSrc": "./assets/logo/light/img35.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img35.svg"
     },
     {
       "id": 36,
       "name": "티브이데일리",
       "darkSrc": "./assets/logo/dark/img36.svg",
-      "lightSrc": "./assets/logo/light/img36.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img36.svg"
     },
     {
       "id": 37,
       "name": "TV Report",
       "darkSrc": "./assets/logo/dark/img37.svg",
-      "lightSrc": "./assets/logo/light/img37.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img37.svg"
     },
     {
       "id": 38,
       "name": "Forbes",
       "darkSrc": "./assets/logo/dark/img38.svg",
-      "lightSrc": "./assets/logo/light/img38.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img38.svg"
     },
     {
       "id": 39,
       "name": "주간경향",
       "darkSrc": "./assets/logo/dark/img39.svg",
-      "lightSrc": "./assets/logo/light/img39.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img39.svg"
     },
     {
       "id": 40,
       "name": "비즈한국",
       "darkSrc": "./assets/logo/dark/img40.svg",
-      "lightSrc": "./assets/logo/light/img40.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img40.svg"
     },
     {
       "id": 41,
       "name": "metro",
       "darkSrc": "./assets/logo/dark/img41.svg",
-      "lightSrc": "./assets/logo/light/img41.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img41.svg"
     },
     {
       "id": 42,
       "name": "JTBC",
       "darkSrc": "./assets/logo/dark/img42.svg",
-      "lightSrc": "./assets/logo/light/img42.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img42.svg"
     },
     {
       "id": 43,
       "name": "조선Biz",
       "darkSrc": "./assets/logo/dark/img43.svg",
-      "lightSrc": "./assets/logo/light/img43.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img43.svg"
     },
     {
       "id": 44,
       "name": "한겨레",
       "darkSrc": "./assets/logo/dark/img44.svg",
-      "lightSrc": "./assets/logo/light/img44.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img44.svg"
     },
     {
       "id": 45,
       "name": "연합뉴스TV",
       "darkSrc": "./assets/logo/dark/img45.svg",
-      "lightSrc": "./assets/logo/light/img45.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img45.svg"
     },
     {
       "id": 46,
       "name": "미디어오늘",
       "darkSrc": "./assets/logo/dark/img46.svg",
-      "lightSrc": "./assets/logo/light/img46.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img46.svg"
     },
     {
       "id": 47,
       "name": "디지털타임스",
       "darkSrc": "./assets/logo/dark/img47.svg",
-      "lightSrc": "./assets/logo/light/img47.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img47.svg"
     },
     {
       "id": 48,
       "name": "OSEN",
       "darkSrc": "./assets/logo/dark/img48.svg",
-      "lightSrc": "./assets/logo/light/img48.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img48.svg"
     },
     {
       "id": 49,
       "name": "소년한국일보",
       "darkSrc": "./assets/logo/dark/img49.svg",
-      "lightSrc": "./assets/logo/light/img49.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img49.svg"
     },
     {
       "id": 50,
       "name": "OBS",
       "darkSrc": "./assets/logo/dark/img50.svg",
-      "lightSrc": "./assets/logo/light/img50.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img50.svg"
     },
     {
       "id": 51,
       "name": "맥스무비",
       "darkSrc": "./assets/logo/dark/img51.svg",
-      "lightSrc": "./assets/logo/light/img51.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img51.svg"
     },
     {
       "id": 52,
       "name": "엑스포츠뉴스",
       "darkSrc": "./assets/logo/dark/img52.svg",
-      "lightSrc": "./assets/logo/light/img52.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img52.svg"
     },
     {
       "id": 53,
       "name": "서울파이낸스",
       "darkSrc": "./assets/logo/dark/img53.svg",
-      "lightSrc": "./assets/logo/light/img53.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img53.svg"
     },
     {
       "id": 54,
       "name": "한국대학신문",
       "darkSrc": "./assets/logo/dark/img54.svg",
-      "lightSrc": "./assets/logo/light/img54.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img54.svg"
     },
     {
       "id": 55,
       "name": "datanews",
       "darkSrc": "./assets/logo/dark/img55.svg",
-      "lightSrc": "./assets/logo/light/img55.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img55.svg"
     },
     {
       "id": 56,
       "name": "DigitalToday",
       "darkSrc": "./assets/logo/dark/img56.svg",
-      "lightSrc": "./assets/logo/light/img56.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img56.svg"
     },
     {
       "id": 57,
       "name": "시사위크",
       "darkSrc": "./assets/logo/dark/img57.svg",
-      "lightSrc": "./assets/logo/light/img57.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img57.svg"
     },
     {
       "id": 58,
       "name": "YTN",
       "darkSrc": "./assets/logo/dark/img58.svg",
-      "lightSrc": "./assets/logo/light/img58.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img58.svg"
     },
     {
       "id": 59,
       "name": "MBN",
       "darkSrc": "./assets/logo/dark/img59.svg",
-      "lightSrc": "./assets/logo/light/img59.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img59.svg"
     },
     {
       "id": 60,
       "name": "매일경제",
       "darkSrc": "./assets/logo/dark/img60.svg",
-      "lightSrc": "./assets/logo/light/img60.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img60.svg"
     },
     {
       "id": 61,
       "name": "오마이뉴스",
       "darkSrc": "./assets/logo/dark/img61.svg",
-      "lightSrc": "./assets/logo/light/img61.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img61.svg"
     },
     {
       "id": 62,
       "name": "SBS",
       "darkSrc": "./assets/logo/dark/img62.svg",
-      "lightSrc": "./assets/logo/light/img62.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img62.svg"
     },
     {
       "id": 63,
       "name": "머니투데이",
       "darkSrc": "./assets/logo/dark/img63.svg",
-      "lightSrc": "./assets/logo/light/img63.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img63.svg"
     },
     {
       "id": 64,
       "name": "마이데일리",
       "darkSrc": "./assets/logo/dark/img64.svg",
-      "lightSrc": "./assets/logo/light/img64.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img64.svg"
     },
     {
       "id": 65,
       "name": "ZDNET Korea",
       "darkSrc": "./assets/logo/dark/img65.svg",
-      "lightSrc": "./assets/logo/light/img65.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img65.svg"
     },
     {
       "id": 66,
       "name": "경향신문",
       "darkSrc": "./assets/logo/dark/img66.svg",
-      "lightSrc": "./assets/logo/light/img66.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img66.svg"
     },
     {
       "id": 67,
       "name": "일간스포츠",
       "darkSrc": "./assets/logo/dark/img67.svg",
-      "lightSrc": "./assets/logo/light/img67.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img67.svg"
     },
     {
       "id": 68,
       "name": "국민일보",
       "darkSrc": "./assets/logo/dark/img68.svg",
-      "lightSrc": "./assets/logo/light/img68.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img68.svg"
     },
     {
       "id": 69,
       "name": "뉴데일리",
       "darkSrc": "./assets/logo/dark/img69.svg",
-      "lightSrc": "./assets/logo/light/img69.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img69.svg"
     },
     {
       "id": 70,
       "name": "뉴스타파",
       "darkSrc": "./assets/logo/dark/img70.svg",
-      "lightSrc": "./assets/logo/light/img70.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img70.svg"
     },
     {
       "id": 71,
       "name": "MBC",
       "darkSrc": "./assets/logo/dark/img71.svg",
-      "lightSrc": "./assets/logo/light/img71.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img71.svg"
     },
     {
       "id": 72,
       "name": "한국헤럴드",
       "darkSrc": "./assets/logo/dark/img72.svg",
-      "lightSrc": "./assets/logo/light/img72.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img72.svg"
     },
     {
       "id": 73,
       "name": "KNN",
       "darkSrc": "./assets/logo/dark/img73.svg",
-      "lightSrc": "./assets/logo/light/img73.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img73.svg"
     },
     {
       "id": 74,
       "name": "CEO스코어데일리",
       "darkSrc": "./assets/logo/dark/img74.svg",
-      "lightSrc": "./assets/logo/light/img74.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img74.svg"
     },
     {
       "id": 75,
       "name": "BUSINESS POST",
       "darkSrc": "./assets/logo/dark/img75.svg",
-      "lightSrc": "./assets/logo/light/img75.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img75.svg"
     },
     {
       "id": 76,
       "name": "에너지경제",
       "darkSrc": "./assets/logo/dark/img76.svg",
-      "lightSrc": "./assets/logo/light/img76.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img76.svg"
     },
     {
       "id": 77,
       "name": "조이뉴스24",
       "darkSrc": "./assets/logo/dark/img77.svg",
-      "lightSrc": "./assets/logo/light/img77.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img77.svg"
     },
     {
       "id": 78,
       "name": "한국농어촌방송",
       "darkSrc": "./assets/logo/dark/img78.svg",
-      "lightSrc": "./assets/logo/light/img78.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img78.svg"
     },
     {
       "id": 79,
       "name": "시사저널e",
       "darkSrc": "./assets/logo/dark/img79.svg",
-      "lightSrc": "./assets/logo/light/img79.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img79.svg"
     },
     {
       "id": 80,
       "name": "법률방송뉴스",
       "darkSrc": "./assets/logo/dark/img80.svg",
-      "lightSrc": "./assets/logo/light/img80.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img80.svg"
     },
     {
       "id": 81,
       "name": "인사이트",
       "darkSrc": "./assets/logo/dark/img81.svg",
-      "lightSrc": "./assets/logo/light/img81.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img81.svg"
     },
     {
       "id": 82,
       "name": "한국중앙데일리",
       "darkSrc": "./assets/logo/dark/img82.svg",
-      "lightSrc": "./assets/logo/light/img82.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img82.svg"
     },
     {
       "id": 83,
       "name": "KBS WORLD",
       "darkSrc": "./assets/logo/dark/img83.svg",
-      "lightSrc": "./assets/logo/light/img83.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img83.svg"
     },
     {
       "id": 84,
       "name": "석간문화일보",
       "darkSrc": "./assets/logo/dark/img84.svg",
-      "lightSrc": "./assets/logo/light/img84.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img84.svg"
     },
     {
       "id": 85,
       "name": "스포츠동아",
       "darkSrc": "./assets/logo/dark/img85.svg",
-      "lightSrc": "./assets/logo/light/img85.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img85.svg"
     },
     {
       "id": 86,
       "name": "소포츠서울",
       "darkSrc": "./assets/logo/dark/img86.svg",
-      "lightSrc": "./assets/logo/light/img86.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img86.svg"
     },
     {
       "id": 87,
       "name": "파이낸셜뉴스",
       "darkSrc": "./assets/logo/dark/img87.svg",
-      "lightSrc": "./assets/logo/light/img87.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img87.svg"
     },
     {
       "id": 88,
       "name": "아이뉴스24",
       "darkSrc": "./assets/logo/dark/img88.svg",
-      "lightSrc": "./assets/logo/light/img88.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img88.svg"
     },
     {
       "id": 89,
       "name": "조선일보",
       "darkSrc": "./assets/logo/dark/img89.svg",
-      "lightSrc": "./assets/logo/light/img89.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img89.svg"
     },
     {
       "id": 90,
       "name": "이데일리",
       "darkSrc": "./assets/logo/dark/img90.svg",
-      "lightSrc": "./assets/logo/light/img90.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img90.svg"
     },
     {
       "id": 91,
       "name": "아시아경제",
       "darkSrc": "./assets/logo/dark/img91.svg",
-      "lightSrc": "./assets/logo/light/img91.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img91.svg"
     },
     {
       "id": 92,
       "name": "세계일보",
       "darkSrc": "./assets/logo/dark/img92.svg",
-      "lightSrc": "./assets/logo/light/img92.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img92.svg"
     },
     {
       "id": 93,
       "name": "SBS Biz",
       "darkSrc": "./assets/logo/dark/img93.svg",
-      "lightSrc": "./assets/logo/light/img93.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img93.svg"
     },
     {
       "id": 94,
       "name": "헤럴드경제",
       "darkSrc": "./assets/logo/dark/img94.svg",
-      "lightSrc": "./assets/logo/light/img94.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img94.svg"
     },
     {
       "id": 95,
       "name": "데일리안",
       "darkSrc": "./assets/logo/dark/img95.svg",
-      "lightSrc": "./assets/logo/light/img95.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img95.svg"
     },
     {
       "id": 96,
       "name": "서울경제",
       "darkSrc": "./assets/logo/dark/img96.svg",
-      "lightSrc": "./assets/logo/light/img96.svg",
-      "isSub": false
+      "lightSrc": "./assets/logo/light/img96.svg"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -36,9 +36,7 @@
         <header class="main_section__header flex_row">
           <wrapper class="main_section__header__title flex_row">
             <h2 class="main_section__header__title--all">전체 언론사</h2>
-            <span class="main_section__header__title--sub"
-              >내가 구독한 언론사</span
-            >
+            <h2 class="main_section__header__title--sub">내가 구독한 언론사</h2>
           </wrapper>
           <wrapper class="main_section__header__button-wrapper flex_row">
             <img class="list_button" src="./assets/icons/list_off.png" alt="" />

--- a/src/category.js
+++ b/src/category.js
@@ -104,28 +104,41 @@ function isTabFull(innerHTML) {
 }
 
 // 카테고리 탭 숫자 업데이트
-function updateCategoryTabNum() {
+function updateCategory() {
   const currentListIdx = getState(listPageIdx);
   const currentCategoryIdx = getState(categoryIdx);
-  const firstCategory = $(".category_list");
-  const clickedCategory = $(`.${CATEGORY_CLICKED}`);
+  const categoryList = $All(".category_list");
+  const clickedCategory = categoryList[currentCategoryIdx];
   $(".now_page", clickedCategory).innerHTML = `${currentListIdx} / `;
-  if (
-    // 다음 카테고리로 넘어가야할 경우
-    isTabFull($(".all_page", clickedCategory).innerHTML)
-  ) {
+  // 카테고리 오른쪽으로 넘어가야할 경우
+  if (isTabFull($(".all_page", clickedCategory).innerHTML)) {
     setState(listPageIdx, 1);
     if (clickedCategory.nextElementSibling === null) {
-      firstCategory.classList.add(CATEGORY_CLICKED);
-      $(".now_page", firstCategory).innerHTML = "1 / ";
+      categoryList[0].classList.add(CATEGORY_CLICKED);
       setState(categoryIdx, 0);
     } else {
       clickedCategory.nextElementSibling.classList.add(CATEGORY_CLICKED);
-      clickedCategory.nextElementSibling.querySelector(".now_page").innerHTML =
-        "1 / ";
       setState(categoryIdx, currentCategoryIdx + 1);
     }
     clickedCategory.classList.remove(CATEGORY_CLICKED);
+  } else if (currentListIdx === 0) {
+    // 카테고리 왼쪽으로 넘어가야할 경우
+    setState(listPageIdx, 1);
+    if (currentCategoryIdx === 0) {
+      // setState(
+      //   listPageIdx,
+      //   parseInt(
+      //     $(".all_page", categoryList[categoryList.length - 1]).innerHTML
+      //   )
+      // );
+      setState(categoryIdx, categoryList.length - 1);
+    } else {
+      setState(categoryIdx, currentCategoryIdx - 1);
+      // setState(
+      //   listPageIdx,
+      //   parseInt($("all_page", categoryList[currentCategoryIdx - 1]).innerHTML)
+      // );
+    }
   }
 }
 
@@ -133,7 +146,7 @@ export async function setCategory() {
   const newsList = await getNewsContents();
   resister(isGrid, startCategoryInterval);
   resister(listPageIdx, refreshInterval);
-  resister(listPageIdx, updateCategoryTabNum);
+  resister(listPageIdx, updateCategory);
   resister(categoryIdx, updateCategoryClicked);
   appendCategoryList(newsList);
 }

--- a/src/global.js
+++ b/src/global.js
@@ -82,6 +82,18 @@ function toggleMainView() {
   const elements = getMainElements();
   changeView(elements, currentMode);
 }
+function updateSubViewButton() {
+  const isSubMode = getState(isSubTab);
+  const subTabButton = $(".main_section__header__title--sub");
+  const allTabButton = $(".main_section__header__title--all");
+  if (isSubMode) {
+    subTabButton.style.color = "#000000";
+    allTabButton.style.color = "#879298";
+  } else {
+    subTabButton.style.color = "#879298";
+    allTabButton.style.color = "#000000";
+  }
+}
 
 function setEvent() {
   const mainLogo = $(".container__header__main");
@@ -102,6 +114,7 @@ function setEvent() {
 (function init() {
   setEvent();
   resister(isGrid, toggleMainView);
+  resister(isSubTab, updateSubViewButton);
 })();
 
 export { updateDate };

--- a/src/global.js
+++ b/src/global.js
@@ -73,10 +73,7 @@ function keyboardClicked(event) {
   } else {
     if (event.key === "ArrowRight") {
       setState(listPageIdx, nowListPage + 1);
-    } else if (
-      event.key === "ArrowLeft" &&
-      (nowListPage - 1 > 0 || getState(categoryIdx) !== 0)
-    ) {
+    } else if (event.key === "ArrowLeft") {
       setState(listPageIdx, nowListPage - 1);
     }
   }

--- a/src/global.js
+++ b/src/global.js
@@ -1,11 +1,6 @@
 import { $, $All } from "./util.js";
 import { getState, resister, setState } from "./observer/observer.js";
-import {
-  categoryIdx,
-  gridPageIdx,
-  isGrid,
-  listPageIdx,
-} from "./store/store.js";
+import { gridPageIdx, isGrid, isSubTab, listPageIdx } from "./store/store.js";
 
 // 로고 새로고침
 function refreshWindow() {
@@ -39,12 +34,6 @@ function changeView(elements, currentMode) {
   elements.rightNavigationButton.style.display = currentMode ? "none" : "block";
 }
 
-function toggleMainView() {
-  const currentMode = getState(isGrid);
-  const elements = getMainElements();
-  changeView(elements, currentMode);
-}
-
 // 오늘 날짜 update
 function updateDate() {
   let today = new Date();
@@ -60,6 +49,7 @@ function updateDate() {
   dateHtml.innerHTML = today;
 }
 
+// 키보드 방향키로 탭 이동
 function keyboardClicked(event) {
   const currentGridMode = getState(isGrid);
   const nowGridPage = getState(gridPageIdx);
@@ -79,17 +69,31 @@ function keyboardClicked(event) {
   }
 }
 
-function toggleButtonClicked() {
+function toggleGridClicked() {
   setState(isGrid, !getState(isGrid));
+}
+
+function toggleSubClicked() {
+  setState(isSubTab, !getState(isSubTab));
+}
+
+function toggleMainView() {
+  const currentMode = getState(isGrid);
+  const elements = getMainElements();
+  changeView(elements, currentMode);
 }
 
 function setEvent() {
   const mainLogo = $(".container__header__main");
   const listButton = $(".list_button");
   const gridButton = $(".grid_button");
+  const subTabButton = $(".main_section__header__title--sub");
+  const allTabButton = $(".main_section__header__title--all");
   mainLogo.addEventListener("click", refreshWindow);
-  listButton.addEventListener("click", toggleButtonClicked);
-  gridButton.addEventListener("click", toggleButtonClicked);
+  listButton.addEventListener("click", toggleGridClicked);
+  gridButton.addEventListener("click", toggleGridClicked);
+  subTabButton.addEventListener("click", toggleSubClicked);
+  allTabButton.addEventListener("click", toggleSubClicked);
   window.addEventListener("keydown", (e) => {
     keyboardClicked(e);
   });

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -25,4 +25,16 @@ const gridPageIdx = initState({
   defaultState: 0,
 });
 
-export { isDarkMode, isGrid, categoryIdx, listPageIdx, gridPageIdx };
+const subscribeList = initState({
+  key: "subscribeList",
+  defaultState: [],
+});
+
+export {
+  isDarkMode,
+  isGrid,
+  categoryIdx,
+  listPageIdx,
+  gridPageIdx,
+  subscribeList,
+};

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -10,6 +10,11 @@ const isGrid = initState({
   defaultState: true,
 });
 
+const isSubTab = initState({
+  key: "isSubTab",
+  defaultState: false,
+});
+
 const categoryIdx = initState({
   key: "categoryIdx",
   defaultState: 0,
@@ -33,6 +38,7 @@ const subscribeList = initState({
 export {
   isDarkMode,
   isGrid,
+  isSubTab,
   categoryIdx,
   listPageIdx,
   gridPageIdx,

--- a/style/style.css
+++ b/style/style.css
@@ -119,6 +119,12 @@ section {
   font-size: 16px;
   color: #879298;
 }
+.main_section__header__title--all:hover {
+  cursor: pointer;
+}
+.main_section__header__title--sub:hover {
+  cursor: pointer;
+}
 
 .main_section__header__button-wrapper {
   gap: 8px;


### PR DESCRIPTION
## ✨ Description
옵저버 패턴 적용 마무리
언론사 구독 기능 구현
구독 탭 그리드 버전 구현

## ✅ To Do List
### 옵저버 패턴 적용
- [x] observer.js
- [x] store.js
- [x] 코드 리팩토링
### 구독 기능
- [x] 구독 버튼 토글 기능
- [x] 구독 상태 저장
- [ ] 구독 스낵바 기능
- [x] state 관리
### 그리드 구독 탭
- [x] 그리드 구독 언론사 탭 css
- [x] 그리드 빈 리스트 추가 기능
-----
- https://github.com/jjun990908/fe-newsstand/issues/3